### PR TITLE
Expose powerDown in base class

### DIFF
--- a/src/GxEPD.h
+++ b/src/GxEPD.h
@@ -49,6 +49,7 @@ class GxEPD : public GxFont_GFX
   public:
     //GxEPD(int16_t w, int16_t h) : Adafruit_GFX(w, h) {};
     GxEPD(int16_t w, int16_t h) : GxFont_GFX(w, h) {};
+    virtual void powerDown(void) { }
     virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
     virtual void init(uint32_t serial_diag_bitrate = 0) = 0; // = 0 : disabled
     virtual void fillScreen(uint16_t color) = 0; // to buffer


### PR DESCRIPTION
Seems like a safe thing to do.  Looks like the only class that doesn't support it is `GxGDEW0154Z04`.  Does a default no-op operation make the interface too leaky?