### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,6 @@ paragraph=GxEPD2 is better suited for new users or new projects!
 category=Display
 url=https://github.com/ZinggJM/GxEPD
 architectures=*
+depends=Adafruit GFX Library
 #next line is for support of Particle development environment, ignored by Arduino IDE
 dependencies.Adafruit_GFX_RK=1.3.5


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format