### PR TITLE
Fixed updateWindow bug

### DIFF
--- a/src/GxGDEH0213B72/GxGDEH0213B72.cpp
+++ b/src/GxGDEH0213B72/GxGDEH0213B72.cpp
@@ -694,7 +694,7 @@ void GxGDEH0213B72::_rotate(uint16_t& x, uint16_t& y, uint16_t& w, uint16_t& h)
     case 1:
       swap(x, y);
       swap(w, h);
-      x = GxGDEH0213B72_WIDTH - x - w - 1;
+      x = GxGDE0213B72B_VISIBLE_WIDTH - x - w - 1;
       break;
     case 2:
       x = GxGDEH0213B72_WIDTH - x - w - 1;


### PR DESCRIPTION

While using rotation(1) (and possible others) the _rotation x-coordinate is wrongly calculated.
It must be calculated based on actual display width and not logical.

Rootcause is missmatch between GxGDE0213B72B_VISIBLE_WIDTH 122 and GxGDE0213B72B_X_PIXELS 128+

Testsketch: [TTGO-EPaper-RotationBugfix.zip](https://github.com/ZinggJM/GxEPD/files/5992198/TTGO-EPaper-RotationBugfix.zip)

Before: 
![1613517344104](https://user-images.githubusercontent.com/3453121/108133928-a3892e00-70b5-11eb-8808-1dbbcbb626db.jpg)

After:
![1613517371846](https://user-images.githubusercontent.com/3453121/108133936-a7b54b80-70b5-11eb-8a16-bf000428c06c.jpg)

