### PR TITLE
Fix byte buffer for drawBitmapBM

### DIFF
--- a/src/GxEPD.cpp
+++ b/src/GxEPD.cpp
@@ -60,7 +60,7 @@ void  GxEPD::drawBitmapBM(const uint8_t *bitmap, uint16_t x, uint16_t y, uint16_
     {
       for (int16_t i = 0; i < w; i++ )
       {
-        if (i & 7) byte <<= 1;
+        if (i & 7) byte >>= 1;
         else
         {
 #if defined(__AVR) || defined(ESP8266) || defined(ESP32)
@@ -70,7 +70,7 @@ void  GxEPD::drawBitmapBM(const uint8_t *bitmap, uint16_t x, uint16_t y, uint16_
 #endif
         }
         // keep using overwrite mode
-        uint16_t pixelcolor = (byte & 0x80) ? fg_color  : bg_color;
+        uint16_t pixelcolor = (byte & 0x01) ? fg_color  : bg_color;
         uint16_t xd = x + i;
         uint16_t yd = y + j;
         if (mode & bm_flip_x) xd = x + w - i;


### PR DESCRIPTION
Buffer previously read pixels in reverse, leading to each 8-pixel segment to be read and displayed in reverse. (Hardware NodeMCU ESP32S, screen GxGDEW029Z10)